### PR TITLE
removed global phantomjs requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "colors": "^1.0.3",
     "node-phantom": "~0.2.5",
     "socket.io": "0.9.6",
-    "underscore": "~1.5.2"
+    "underscore": "~1.5.2",
+    "phantomjs": "^1.9.17"
   }
 }

--- a/src/banquo.js
+++ b/src/banquo.js
@@ -36,7 +36,7 @@ function banquo(opts, callback) {
 
   console.log(colors.cyan('Requesting...'), settings.url);
 
-  phantom.create(createPage)
+  phantom.create(createPage,{phantomPath:require('phantomjs').path});
 
   function createPage(err, _ph) {
     ph = _ph;


### PR DESCRIPTION
If we add the phantomjs module, we can use node-phantom's  'phantomPath' option. This allows us to avoid the requirement for a global install of an old phantomjs version (and a global install of anything, for that matter.) Helps devs who need different versions of phantomjs, and helps deploy by not having to install phantom on server.