### PR TITLE
added height option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+## Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+*.iml
+
+## Directory-based project format:
+**.idea/
+
+**.DS_Store
+
 node_modules
 image_*

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Key | Required | Default | Options | Description
 mode |no| `base64` | `save` or `base64`  | The former will save a file to the `out_file` location and return a success string callback. The latter will return the image as a base64 string.
 url |yes| null | *String* | The website you want to screenshot.
 viewport_width |no| 1440 | *Number (Pixels)* | The desired browser width. Settings this to a higher number will increase processing time.
+viewport_height |no| 900 | *Number (Pixels)* | The desired browser height. Settings this to a higher number will increase processing time. May be useful with long scrolls in fixed height containers.
 delay |no| 1000 | *Number (Milliseconds)* | How long to wait after the page has loaded before taking the screenshot. PhantomJS apparently waits for the page to load but if you have a map or other data calculations going on, you'll need to specify a wait time.
 selector |no| `body` | *String (CSS selector)* | The div you want to screenshot.
 css_hide |no| null | *String (CSS selector)* | Any divs you want to hide, such as zoom buttons on map. Defaults to none.

--- a/src/banquo.js
+++ b/src/banquo.js
@@ -11,6 +11,7 @@ function banquo(opts, callback) {
   var settings = _.extend({
     mode: 'base64',
     viewport_width: 1440,
+    viewport_height: 900,
     delay: 1000,
     selector: 'body',
     css_file: '',
@@ -57,7 +58,7 @@ function banquo(opts, callback) {
           loadImages: true
         });
     }
-    page.set('viewportSize', {width: settings.viewport_width, height: 900});
+    page.set('viewportSize', {width: settings.viewport_width, height: settings.viewport_height});
     page.open(settings.url, prepForRender);
   }
 


### PR DESCRIPTION
Does not change previous functionality, but allows user to specify viewport_height. This can be useful if there is a fixed height container that overflows-y and has long scroll.