### PR TITLE
phantomjs-webfonts build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 node_modules
 image_*
+
+## Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+*.iml
+
+## Directory-based project format:
+**.idea/
+
+**.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "banquo",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Michael Keller <michael.keller@aljazeera.net> (http://github.com/ajam/banquo)",
   "contributors": [
     "Michael Keller"
@@ -13,7 +13,7 @@
   "dependencies": {
     "chalk": "^1.1.0",
     "node-phantom": "~0.2.5",
-    "phantomjs": "^1.9.17",
+    "phantomjs-webfonts": "^1.9.3",
     "socket.io": "0.9.6",
     "underscore": "~1.5.2"
   },

--- a/src/banquo.js
+++ b/src/banquo.js
@@ -4,7 +4,7 @@ var fs            = require('fs'),
     _             = require('underscore'),
     phantom       = require('node-phantom'),
     chalk         = require('chalk'),
-    phantomjs     = require('phantomjs');
+    phantomjs     = require('phantomjs-webfonts');
 
 function banquo(opts, callback) {
   var now = new Date().toISOString().split('T')[0] // '2015-08-07T16:33:29.571Z' => '2015-08-07'


### PR DESCRIPTION
replacing standard phantomjs 1.9.17 with webfonts-capable build 1.9.3. test still succeeds. Closes ajam/banquo#6.